### PR TITLE
Rename to @edge.app/ecpair + bump to 2.1.0-edge.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ecpair",
-  "version": "2.1.0",
-  "description": "Client-side Bitcoin JavaScript library ECPair",
+  "name": "@edge.app/ecpair",
+  "version": "2.1.0-edge.1",
+  "description": "Client-side Bitcoin JavaScript library ECPair (Edge fork — adds custom base58 encode/decode for altcoins)",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "engines": {
@@ -81,5 +81,8 @@
     "tslint": "^6.1.3",
     "typescript": "^4.4.4"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary

Renames this package to **`@edge.app/ecpair`** and bumps to `2.1.0-edge.1`, with `publishConfig.access = "public"`. After merging, publish manually:

```bash
git checkout master && git pull
npm ci && npm run build
npm publish --access public
```

## Why

EdgeApp's `edge-currency-plugins` (and transitively `edge-exchange-plugins`) currently pulls this fork in via a git URL. That triggers an npm bug ([npm/cli#9005](https://github.com/npm/cli/issues/9005)) when `min-release-age` is set in user-level `~/.npmrc`. Publishing as a regular npm package eliminates the git-dep code path.

## How consumers use it

Because the original `ecpair` name on npm is owned by bitcoinjs, the EdgeApp fork is scoped. Consumers can use npm's package-alias feature to keep `require('ecpair')` in source untouched:

```json
"dependencies": {
  "ecpair": "npm:@edge.app/ecpair@^2.1.0-edge.1"
}
```

## Test plan
- [ ] Land this PR
- [ ] `npm publish --access public` from a clean checkout of `master`
- [ ] Confirm `@edge.app/ecpair@2.1.0-edge.1` appears on npm
- [ ] Use the alias in a follow-up PR on `edge-currency-plugins` and verify `sfw npm install` works cleanly with `min-release-age=7`